### PR TITLE
turn off CGO when building envoy-xds-server binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ADD . /build/
 WORKDIR /build
 
 # Build the binary
-RUN go build -o envoy-xds-server ./cmd/server/main.go
+RUN CGO_ENABLED=0 go build -o envoy-xds-server ./cmd/server/main.go
 
 # Copy into scratch
 FROM scratch


### PR DESCRIPTION
### Problem description
With the CGO option turned on, I get below error when I build docker image using current Dockerfile and run it.
```
$ sudo docker logs xds
standard_init_linux.go:228: exec user process caused: no such file or directory
```

### Root cause
The scratch image doesn't have required dependencies for the xds server binary

### Solution
I add CGO_ENABLED=0 to the front of go build command